### PR TITLE
Updating the background colour of app.

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -18,7 +18,7 @@ body,
 #root {
   height: 100%;
   width: 100%;
-  background-color: var(--diamond-blue);
+  background-color: var(--light-text);
 }
 html,
 body {


### PR DESCRIPTION
Updating the background colour so that it matches the OPI background in the case that the height of the OPI screens is less than the screen height. In previous releases the background was set to to blue.

This, along with the PR in cs-wel-lib (https://github.com/dls-controls/cs-web-lib/pull/3) will fix the issue described here: https://github.com/dls-controls/machine-status/issues/2.