### PR TITLE
Removing 'Content' div.

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -125,7 +125,7 @@ class RedirectAfterTimeout extends Component<Props> {
     return this.state.redirect ? (
       <Redirect to={this.props.urlpath} />
     ) : (
-      <div>Content</div>
+      <div></div>
     );
   }
 }


### PR DESCRIPTION
I have removed the 'Content' text that was being added at the bottom of the rendered display. It was only on the 'message' screen that this appeared as the other OPI files defined larger heights which pushed the 'Content' out of view. While removing the 'Content' text solves this problem, the route cause of this being displayed has been fixed in https://github.com/dls-controls/cs-web-lib/pull/3.